### PR TITLE
[BREAKING CHANGE] Add example env file and refactor of Infura API Token as an env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+VUE_APP_SPELL_APR_URL=""
+
+# Coingecko API token
+VUE_APP_COINGECKO_API_KEY_2=""
+
+# Infura API token
+VUE_APP_WEB3_INFURA_PROJECT_ID=""

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 npm install
 ```
 
+### Setting environment variables
+The file .env.example will help you to set the env variables needed for the project.
+
+Rename the ".env.example" file to ".env" and fill the environment variables required.
+
 ### Compiles and hot-reloads for development
 ```
 npm run serve

--- a/src/helpers/spellStake/spellStakingApr.js
+++ b/src/helpers/spellStake/spellStakingApr.js
@@ -1,5 +1,5 @@
 const MAINNET_URL =
-  "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+  `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`;
 
 import { ethers, Contract } from "ethers";
 

--- a/src/helpers/stargateFarmApy.js
+++ b/src/helpers/stargateFarmApy.js
@@ -1,5 +1,5 @@
 const { BigNumber, providers, Contract } = require("ethers");
-const url = "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+const url = `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`;
 const { Percent, CurrencyAmount, Token } = require("@uniswap/sdk");
 
 import lpStakingAbi from "@/utils/abi/StargateLPStaking";

--- a/src/plugins/connectWallet/index.js
+++ b/src/plugins/connectWallet/index.js
@@ -10,7 +10,7 @@ const walletconnect = {
   package: WalletConnectProvider,
   options: {
     rpc: {
-      1: "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+      1: `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`,
       10: "https://mainnet.optimism.io",
       56: "https://bsc-dataseed.binance.org/",
       250: "https://rpc.ftm.tools/",
@@ -25,7 +25,7 @@ const coinbasewallet = {
   options: {
     appName: "abracadabra.money", // Required
     rpc: {
-      1: "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+      1: `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`,
       10: "https://mainnet.optimism.io",
       56: "https://bsc-dataseed.binance.org/",
       250: "https://rpc.ftm.tools/",
@@ -99,7 +99,7 @@ const initWithoutConnect = async () => {
 
 const checkSanctionAddress = async (address) => {
   const provider = new ethers.providers.JsonRpcProvider(
-    "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+    `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`
   );
 
   const contract = new ethers.Contract(

--- a/src/store/modules/connectProvider.js
+++ b/src/store/modules/connectProvider.js
@@ -46,7 +46,7 @@ export default {
     async checkENSName({ commit }, address) {
       try {
         const ensName = await new ethers.providers.StaticJsonRpcProvider(
-          "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
+          `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`
         ).lookupAddress(address);
 
         if (ensName) {

--- a/src/store/modules/networks.js
+++ b/src/store/modules/networks.js
@@ -12,7 +12,7 @@ export default {
       {
         chainId: 1,
         name: "ETH",
-        rpc: "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+        rpc: `https://mainnet.infura.io/v3/${process.env.VUE_APP_WEB3_INFURA_PROJECT_ID}`,
         icon: ethIcon,
         switchData: {
           chainId: "0x01",


### PR DESCRIPTION
## Description
A `.env.example` file was added as a file template that have all the env variables needed to start the project. To use the template, the dev will only have to rename the `.env.example` to `.env` and set the variables indicated in the file to start the project. This critical info was added into the `README.md` to help with the onboarding of the project.

Also, I refactor the Infura API token in the codebase as an env variable because it was hard-coded in several files. If the PR is accepted, **current devs will have to set the Infura API token in the `.env` file**, this way there are no secrets hard-coded (unless you wanted that way in the future). The env variable for the Infura API token is `VUE_APP_WEB3_INFURA_PROJECT_ID` (the variable name was set based on [eth-brownie docs](https://eth-brownie.readthedocs.io/en/v1.6.7/config.html#:~:text=host%3A%20https%3A//mainnet.infura.io/v3/%24WEB3_INFURA_PROJECT_ID))

## Motivation and Context
Given that the project is now open sourced, more devs will try to contribute to the project and they will need a way to know which env variables they need to set to start the project. The use of the `.env.example` file comes from the [Laravel strategy](https://stackoverflow.com/questions/52084447/what-is-the-need-for-env-and-env-example-files-in-laravel) to set a template with all the env variables needed in the project.

## How Has This Been Tested?
Manually. I set the Infura API token in the .env file and then checked that the Infura API calls were successful with the token.
