### PR TITLE
Add .env file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 
 
 # local env files
+.env
 .env.local
 .env.*.local
 


### PR DESCRIPTION
## Description
Add .env file to .gitignore

## Motivation and Context
To make sure that secrets can't be store even by accident, the .env file should always be ignored by git.

## How Has This Been Tested?
Tried to commit the .env file after being ignored by git and it didn't let me do it.