### PR TITLE
Fix minor bug with /markets route

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -82,7 +82,6 @@ const routes = [
   },
   {
     path: "/markets",
-    name: "Markets",
     component: () => import("@/views/markets/Markets"),
     children: [
       {


### PR DESCRIPTION
## Description
Remove name property of the /markets route.

## Motivation and Context
![image](https://user-images.githubusercontent.com/11968584/208954366-1911e86b-c12c-4f04-9253-7d7f8a078cc6.png)

## How Has This Been Tested?
Navigate to /markets route using the Markets button in Tools, and it's still working, but without the error.