### PR TITLE
[BREAKING CHANGE] Fix links to the docs

### DIFF
--- a/src/components/myPositions/BalanceBox.vue
+++ b/src/components/myPositions/BalanceBox.vue
@@ -67,9 +67,9 @@ export default {
   computed: {
     link() {
       if (this.isBento)
-        return "https://docs.abracadabra.money/intro/the-dashboard#mim-balance-on-bentobox";
+        return (process.env.VUE_APP_BASE_DOCS_URL + "/intro/the-dashboard#mim-balance-on-bentobox-degenbox");
 
-      return "https://docs.abracadabra.money/our-ecosystem/our-contracts#our-degenbox-contracts";
+      return (process.env.VUE_APP_BASE_DOCS_URL + "/our-ecosystem/our-contracts#our-degenbox-contracts");
     },
     parsedBalance() {
       return this.$ethers.utils.formatEther(this.balance);

--- a/src/components/stake/EmptyBlock.vue
+++ b/src/components/stake/EmptyBlock.vue
@@ -32,13 +32,13 @@ export default {
       img: require(`@/assets/images/empty_borrow.png`),
       text: "Please use Ethereum Mainnet to stake Spell",
       bottom: "If you want to learn more read our docs",
-      link: "https://docs.abracadabra.money/intro/stake/sspell",
+      link: process.env.VUE_APP_BASE_DOCS_URL + "/intro/stake/sspell",
     },
     emptyDataMSpell: {
       img: require(`@/assets/images/empty_borrow.png`),
       text: "mSPELL staking is available on Avalanche, Arbitrum, Ethereum and Fantom Opera!",
       bottom: "If you want to learn more read our docs",
-      link: "https://docs.abracadabra.money/intro/stake/mspell",
+      link: process.env.VUE_APP_BASE_DOCS_URL + "/intro/stake/mspell",
     },
   }),
   computed: {

--- a/src/components/stake/InfoBlock.vue
+++ b/src/components/stake/InfoBlock.vue
@@ -74,7 +74,7 @@ export default {
       img: require(`@/assets/images/empty_borrow.png`),
       text: "Some text 4 empty view!",
       bottom: "If you want to learn more read our docs",
-      link: "https://docs.abracadabra.money/",
+      link: process.env.VUE_APP_BASE_DOCS_URL,
     },
   }),
   computed: {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -63,7 +63,7 @@
           <a
             target="_blank"
             rel="noreferrer noopener"
-            href="https://docs.abracadabra.money/intro/lending-markets"
+            :href="baseDocsUrl + '/intro/lending-markets'"
             class="link"
             >Read more</a
           >
@@ -107,7 +107,7 @@
           <a
             target="_blank"
             rel="noreferrer noopener"
-            href="https://docs.abracadabra.money/tokens/tokenomics#the-mim-token"
+            :href="baseDocsUrl + '/tokens/tokenomics#the-mim-token'"
             class="link"
             >Read more</a
           >
@@ -132,7 +132,7 @@
           <a
             rel="noreferrer noopener"
             target="_blank"
-            href="https://docs.abracadabra.money/intro/leveraged-positions"
+            :href="baseDocsUrl + '/intro/leveraged-positions'"
             class="link"
             >Read more about Abracadabra Ecosystem</a
           >
@@ -155,6 +155,9 @@ export default {
     showScrollBlock() {
       return this.lastKnownScrollPosition === 0;
     },
+    baseDocsUrl () {
+      return process.env.VUE_APP_BASE_DOCS_URL;
+    }
   },
   methods: {
     toBorrowPage() {

--- a/src/views/borrow/Borrow.vue
+++ b/src/views/borrow/Borrow.vue
@@ -183,7 +183,7 @@ export default {
         img: require(`@/assets/images/empty_borrow.png`),
         text: "Choose the asset and amount you want to use as collateral as well as the amount of MIM you want to Borrow",
         bottom: "If you want to learn more read our docs",
-        link: "https://docs.abracadabra.money/intro/lending-markets",
+        link: process.env.VUE_APP_BASE_DOCS_URL + "/intro/lending-markets",
       },
       ltvTooltip:
         "Loan to Value: percentage of debt compared to the collateral. The higher it is, the riskier the position",

--- a/src/views/borrow/Deleverage.vue
+++ b/src/views/borrow/Deleverage.vue
@@ -163,7 +163,7 @@ export default {
         img: require(`@/assets/images/empty_leverage.png`),
         text: "Deleverage your position using our built-in Flash repay function.",
         bottom: "Read more about it",
-        link: "https://docs.abracadabra.money/intro/lending-markets",
+        link: process.env.VUE_APP_BASE_DOCS_URL + "/intro/lending-markets",
       },
     };
   },

--- a/src/views/borrow/Leverage.vue
+++ b/src/views/borrow/Leverage.vue
@@ -174,7 +174,7 @@ export default {
         img: require(`@/assets/images/empty_leverage.png`),
         text: "Leverage up your selected asset using our built in function. Remember you will not receive any MIMs.",
         bottom: "Read more about it",
-        link: "https://docs.abracadabra.money/intro/lending-markets",
+        link: process.env.VUE_APP_BASE_DOCS_URL + "/intro/lending-markets"
       },
     };
   },

--- a/src/views/borrow/Repay.vue
+++ b/src/views/borrow/Repay.vue
@@ -123,7 +123,7 @@ export default {
         img: require(`@/assets/images/empty_borrow.png`),
         text: "Choose the asset and amount you want to use as collateral as well as the amount of MIM you want to Repay",
         bottom: "If you want to learn more read our docs",
-        link: "https://docs.abracadabra.money/",
+        link: process.env.VUE_APP_BASE_DOCS_URL,
       },
     };
   },

--- a/src/views/stake/MSpell.vue
+++ b/src/views/stake/MSpell.vue
@@ -82,7 +82,7 @@
             sharing mechanism of Abracadabra and earn MIM! Find out more
             <a
               target="_blank"
-              href="https://docs.abracadabra.money/intro/stake/mspell"
+              :href="baseDocsUrl + '/intro/stake/mspell'"
               class="empty-link"
               >here</a
             >!
@@ -121,6 +121,9 @@ export default {
     };
   },
   computed: {
+    baseDocsUrl () {
+      return process.env.VUE_APP_BASE_DOCS_URL;
+    },
     account() {
       return this.$store.getters.getAccount;
     },


### PR DESCRIPTION
## Description
Creates a base URL for the docs by creating an env variable called `VUE_APP_BASE_DOCS_URL ` that should point to the docs page. By using a base URL for the docs, this one can be easily changed in the future if needed.

Using the newly created env variable, I refactored every URL pointing to the docs to include the env variable and concatenated with its corresponded nested path.

Currently, the original doc's subdomain [`https://docs.abracadabra.money`](https://docs.abracadabra.money) is down but using the the gitbook URL [`https://abracadabramoney.gitbook.io/learn`](https://abracadabramoney.gitbook.io/learn) instead, we can access the same docs, so the idea is to use the gitbook URL as the value of the new env var to fix the issue with the access to the docs.

The env file should look like this: 
```
//.env
VUE_APP_BASE_DOCS_URL="https://abracadabramoney.gitbook.io/learn"
```

And just like that, the docs are now available and the URL used for the docs can be changed to the original one when the Cloudflare issue is fixed.

⚠️ _Note: if the PR is accepted, the new env var mentioned in this PR must be added to the env variables set in Vercel for the URL to the docs works as expected in production._

## Motivation and Context
![image](https://user-images.githubusercontent.com/11968584/211163743-95f8060f-50fb-451e-8b5d-12d8c10a84cc.png)

All links related to the docs are down due to Cloudflare and while the team is working on finding a solution, most of the documentation can be found in the gitbook URL of the project, so that's why I changed the URLs to point to the gitbook URL while the team fixed the Cludflare issue, that way, the community can browse the docs again without problem and the team can work to solve the issue with less pressure.

## How Has This Been Tested?
Manually. The links point to the same info as before.
