### PR TITLE
Changing JsonRpcProvider to StaticJsonRpcProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+.prettierignore

--- a/src/components/ui/MimTokenBlock.vue
+++ b/src/components/ui/MimTokenBlock.vue
@@ -87,7 +87,7 @@ export default {
     },
 
     async initContract() {
-      const defaultProvider = new providers.JsonRpcProvider(
+      const defaultProvider = new providers.StaticJsonRpcProvider(
         "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
       );
 

--- a/src/helpers/glpApr/contracts.js
+++ b/src/helpers/glpApr/contracts.js
@@ -17,7 +17,7 @@ const {
   GmxGlpWrapperAddress,
 } = require("./constants");
 
-const provider = new providers.JsonRpcProvider(rpc);
+const provider = new providers.StaticJsonRpcProvider(rpc);
 
 module.exports.getGlpManagerContract = () =>
   new Contract(glpManagerAddress, GlpManager.abi, provider);

--- a/src/helpers/stargateFarmApy.js
+++ b/src/helpers/stargateFarmApy.js
@@ -5,7 +5,7 @@ const { Percent, CurrencyAmount, Token } = require("@uniswap/sdk");
 import lpStakingAbi from "@/utils/abi/StargateLPStaking";
 import poolAbi from "@/utils/abi/StargatePool";
 
-const provider = new providers.JsonRpcProvider(url);
+const provider = new providers.StaticJsonRpcProvider(url);
 const YEAR = 31536000;
 
 const stgToken = new Token(1, "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6", 18);

--- a/src/mixins/farmPools.js
+++ b/src/mixins/farmPools.js
@@ -34,7 +34,7 @@ export default {
         });
       }
 
-      return new this.$ethers.providers.JsonRpcProvider(networkRpc);
+      return new this.$ethers.providers.StaticJsonRpcProvider(networkRpc);
     },
   },
   methods: {

--- a/src/plugins/connectWallet/index.js
+++ b/src/plugins/connectWallet/index.js
@@ -85,7 +85,7 @@ const subscribeProvider = async (provider, isCoinbase) => {
 
 const initWithoutConnect = async () => {
   const chainId = +(localStorage.getItem("MAGIC_MONEY_CHAIN_ID") || 1);
-  const provider = new ethers.providers.JsonRpcProvider(
+  const provider = new ethers.providers.StaticJsonRpcProvider(
     walletconnect.options.rpc[chainId]
   );
 
@@ -98,7 +98,7 @@ const initWithoutConnect = async () => {
 };
 
 const checkSanctionAddress = async (address) => {
-  const provider = new ethers.providers.JsonRpcProvider(
+  const provider = new ethers.providers.StaticJsonRpcProvider(
     "https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161"
   );
 


### PR DESCRIPTION
Changing JsonRpcProvider to StaticJsonRpcProvider, which eliminates unnecessary calls to the node for eth_callId.

This seems to reduce RPC calls made by the cauldrons.js file by almost 40% when a user's wallet is not connected.

See https://github.com/ethers-io/ethers.js/issues/901