### PR TITLE
Ensuring that we remove the entirety of the unwrapped token to the users address.

### DIFF
--- a/src/mixins/borrow/cooks.js
+++ b/src/mixins/borrow/cooks.js
@@ -1271,9 +1271,11 @@ export default {
       } else {
         // 21
         // withdraw to  userAddr
+        let unwrappedAmount = await pool.collateralToken.contract.toAmount(amount)
+
         const lpWrapperEncode = this.$ethers.utils.defaultAbiCoder.encode(
           ["address", "address", "int256", "int256"],
-          [lpAddress, userAddr, amount, "0"]
+          [lpAddress, userAddr, unwrappedAmount, "0"]
         );
 
         lpRemoveCollateralEventsArray.push(21);


### PR DESCRIPTION
Unwrapped token does not have a 1:1 ratio with the wrapped token and so should be converted before being transferred back to the user's wallet.