### PR TITLE
🐞 Fix harvest on MultiRewardFarm when rewards > 1k

### DIFF
--- a/src/components/myPositions/FarmPositionItem.vue
+++ b/src/components/myPositions/FarmPositionItem.vue
@@ -58,8 +58,7 @@ export default {
 
     assetsInfo() {
       const disableEarnedButton = this.farmConfig.isMultiReward
-        ? this.multiRewardsTokens?.filter((tokenInfo) => +tokenInfo.amount > 0)
-            .length === 0
+        ? this.multiRewardsTokens?.find((tokenInfo) => tokenInfo.amount !== "0.0") === undefined
         : !+this.earnedData.balance;
 
       return [


### PR DESCRIPTION
Existing implementation converted `tokenInfo.amount` to a number, but it is a formatted string, so when it contained commas it became `NaN` e.g. with `"1,200.111"`. This PR switched to string comparison instead.